### PR TITLE
Way to process selected objects from the input JSON stream

### DIFF
--- a/src/JsonStreamingParser/Listener/SubsetConsumer.php
+++ b/src/JsonStreamingParser/Listener/SubsetConsumer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace JsonStreamingParser\Listener;
+
+abstract class SubsetConsumer implements \JsonStreamingParser_Listener
+{
+  private $keyValueStack;
+  private $key;
+
+  /**
+   * @param mixed $data
+   * @return boolean if data was consumed and can be discarded
+   */
+  abstract protected function consume($data);
+
+  public function start_document()
+  {
+    $this->keyValueStack = array();
+  }
+
+  public function end_document()
+  {
+  }
+
+  public function start_object()
+  {
+    array_push($this->keyValueStack, is_null($this->key) ? array(array()) : array($this->key => array()));
+    $this->key = null;
+  }
+
+  public function end_object()
+  {
+    $keyValue = array_pop($this->keyValueStack);
+    $obj = reset($keyValue);
+    $this->key = key($keyValue);
+    $hasBeenConsumed = $this->consume($obj);
+
+    if (!empty($this->keyValueStack)) {
+      $this->value($hasBeenConsumed ? '*consumed*' : $obj);
+    }
+
+  }
+
+  public function start_array()
+  {
+    $this->start_object();
+  }
+
+  public function end_array()
+  {
+    $this->end_object();
+  }
+
+  public function key($key)
+  {
+    $this->key = $key;
+  }
+
+  public function value($value)
+  {
+    $keyValue = array_pop($this->keyValueStack);
+    $objKey = key($keyValue);
+
+    if ($this->key) {
+      $keyValue[$objKey][$this->key] = $value;
+    } else {
+      array_push($keyValue[$objKey], $value);
+    }
+    array_push($this->keyValueStack, $keyValue);
+  }
+}

--- a/tests/Listener/SubsetConsumerTest.php
+++ b/tests/Listener/SubsetConsumerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace JsonStreamingParser\Listener;
+
+class SubsetConsumerTest extends \PHPUnit_Framework_TestCase
+{
+  public function testProposesAJsonSubsetToConsume()
+  {
+    $listener = new DatesRangeConsumer;
+    $parser = new \JsonStreamingParser_Parser(fopen(__DIR__ . '/data/dateRanges.json', 'r'), $listener);
+    $parser->parse();
+
+    $this->assertSame(
+      array(
+        array(
+          'startDate' => '2013-10-24',
+          'endDate' => '2013-10-25',
+        ),
+        array(
+          'startDate' => '2013-10-26',
+          'endDate' => '2013-10-27',
+        ),
+        array(
+          'startDate' => '2013-11-01',
+          'endDate' => '2013-11-10',
+        ),
+      ),
+      $listener->dateRanges
+    );
+  }
+
+  public function testConsumesFirstLevelCorrectly()
+  {
+    $listener = new IdealConsumer;
+    $parser = new \JsonStreamingParser_Parser(fopen(__DIR__ . '/data/plain.json', 'r'), $listener);
+    $parser->parse();
+
+    $this->assertEquals(
+      array('key 1' => 'value 1', 'key 2' => 'value 2', 'key 3' => 'value 3'),
+      $listener->data
+    );
+  }
+
+  public function testCollectsStructureCorrectly()
+  {
+    $listener = new IdealConsumer;
+    $parser = new \JsonStreamingParser_Parser(fopen(__DIR__ . '/../../example/example.json', 'r'), $listener);
+    $parser->parse();
+
+    $this->assertEquals(
+      json_decode(file_get_contents(__DIR__ . '/../../example/example.json'), true),
+      $listener->data
+    );
+
+  }
+}
+
+//======================================================================================================================
+
+class DatesRangeConsumer extends SubsetConsumer
+{
+
+  public $dateRanges = array();
+
+  /**
+   * @param mixed $data
+   * @return boolean if data was consumed
+   */
+  protected function consume($data)
+  {
+    if (is_array($data) && array_key_exists('startDate', $data) && array_key_exists('endDate', $data)) {
+      $this->dateRanges[] = $data;
+      return true;
+    }
+    return false;
+  }
+}
+
+//======================================================================================================================
+
+class IdealConsumer extends SubsetConsumer
+{
+
+  public $data = array();
+
+  /**
+   * Consumes anything
+   *
+   * @param mixed $data
+   * @return boolean if data was consumed and can be discarded
+   */
+  protected function consume($data)
+  {
+    $this->data = $data;
+    return false;
+  }
+}

--- a/tests/Listener/data/dateRanges.json
+++ b/tests/Listener/data/dateRanges.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {"rows" :
+      [
+        {"startDate": "2013-10-24", "endDate": "2013-10-25"},
+        {"startDate": "2013-10-26", "endDate": "2013-10-27"}
+      ]
+    }
+  ],
+  "anotherPlace": {"startDate": "2013-11-01", "endDate": "2013-11-10"}
+}

--- a/tests/Listener/data/plain.json
+++ b/tests/Listener/data/plain.json
@@ -1,0 +1,5 @@
+{
+  "key 1" : "value 1",
+  "key 2" : "value 2",
+  "key 3" : "value 3"
+}


### PR DESCRIPTION
It is common task to parse out some JSON object from the input stream to process it somehow. There is [JsonPath](http://goessner.net/articles/JsonPath/), but I propose to do it in other way.
SubsetConsumer class calls function consume() for each complete object from the stream. User's code can whether "consume" that object or not. See test for use cases tests/Listener/SubsetConsumerTest.php.
