### PR TITLE
Fix example in-memory parser's key handling

### DIFF
--- a/example/InMemoryListener.php
+++ b/example/InMemoryListener.php
@@ -1,0 +1,89 @@
+<?php
+
+require_once dirname(__FILE__).'/../src/JsonStreamingParser/Listener/IdleListener.php';
+
+/**
+ * This basic implementation of a listener simply constructs an in-memory
+ * representation of the JSON document, which is a little silly since the whole
+ * point of a streaming parser is to avoid doing just that. However, it can
+ * serve as a starting point for more complex listeners, and illustrates some
+ * useful concepts for working with a streaming-style parser.
+ */
+class InMemoryListener implements JsonStreamingParser_Listener_IdleListener {
+  private $_result;
+
+  private $_stack;
+  private $_keys;
+
+  public function get_json() {
+    return $this->_result;
+  }
+
+  public function start_document() {
+    $this->_stack = array();
+    $this->_keys = array();
+  }
+
+  public function start_object() {
+    $this->_start_complex_value('object');
+  }
+
+  public function end_object() {
+    $this->_end_complex_value();
+  }
+
+  public function start_array() {
+    $this->_start_complex_value('array');
+  }
+
+  public function end_array() {
+    $this->_end_complex_value();
+  }
+
+  public function key($key) {
+    array_push($this->_keys, $key);
+  }
+
+  public function value($value) {
+    $this->_insert_value($value);
+  }
+
+  private function _start_complex_value($type) {
+    // We keep a stack of complex values (i.e. arrays and objects) as we build them,
+    // tagged with the type that they are so we know how to add new values.
+    $current_item = array('type' => $type, 'value' => array());
+    array_push($this->_stack, $current_item);
+  }
+
+  private function _end_complex_value() {
+    $obj = array_pop($this->_stack)['value'];
+
+    // If the value stack is now empty, we're done parsing the document, so we can
+    // move the result into place so that get_json() can return it. Otherwise, we 
+    // associate the value 
+    if (empty($this->_stack)) {
+      $this->_result = $obj;
+    } else {
+      $this->_insert_value($value);
+    }
+  }
+
+  // Inserts the given value into the top value on the stack in the appropriate way,
+  // based on whether that value is an array or an object.
+  private function _insert_value($value) {
+    // Grab the top item from the stack that we're currently parsing.
+    $current_item = array_pop($this->_stack);
+
+    // Examine the current item, and then:
+    //   - if it's an object, associate the newly-parsed value with the most recent key
+    //   - if it's an array, push the newly-parsed value to the array
+    if ($current_item['type'] === 'object') {
+      $current_item['value'][array_pop($this->_keys)] = $value;
+    } else {
+      array_push($current_item['value'], $value);
+    }
+
+    // Replace the current item on the stack.
+    array_push($this->_stack, $current_item);
+  }
+}

--- a/example/example.php
+++ b/example/example.php
@@ -1,84 +1,11 @@
 <?php
-require_once dirname(__FILE__).'/../src/JsonStreamingParser/Listener.php';
+
 require_once dirname(__FILE__).'/../src/JsonStreamingParser/Parser.php';
-
-/**
- * This basic implementation of a listener simply constructs an in-memory
- * representation of the JSON document, which is a little silly since the whole
- * point of a streaming parser is to avoid doing just that. However, it gets
- * the point across.
- */
-class ArrayMaker implements JsonStreamingParser_Listener {
-  private $_json;
-
-  private $_stack;
-  private $_key;
-
-  public function file_position($line, $char) {
-
-  }
-
-  public function get_json() {
-    return $this->_json;
-  }
-
-  public function start_document() {
-    $this->_stack = array();
-
-    $this->_key = null;
-  }
-
-  public function end_document() {
-    // w00t!
-  }
-
-  public function start_object() {
-    array_push($this->_stack, array());
-  }
-
-  public function end_object() {
-    $obj = array_pop($this->_stack);
-    if (empty($this->_stack)) {
-      // doc is DONE!
-      $this->_json = $obj;
-    } else {
-      $this->value($obj);
-    }
-  }
-
-  public function start_array() {
-    $this->start_object();
-  }
-
-  public function end_array() {
-    $this->end_object();
-  }
-
-  // Key will always be a string
-  public function key($key) {
-    $this->_key = $key;
-  }
-
-  // Note that value may be a string, integer, boolean, null
-  public function value($value) {
-    $obj = array_pop($this->_stack);
-    if ($this->_key) {
-      $obj[$this->_key] = $value;
-      $this->_key = null;
-    } else {
-      array_push($obj, $value);
-    }
-    array_push($this->_stack, $obj);
-  }
-
-  public function whitespace($whitespace) {
-    // do nothing
-  }
-}
+require_once dirname(__FILE__).'/InMemoryListener.php';
 
 $testfile = dirname(__FILE__).'/example.json';
 
-$listener = new ArrayMaker();
+$listener = new InMemoryListener();
 $stream = fopen($testfile, 'r');
 try {
   $parser = new JsonStreamingParser_Parser($stream, $listener);

--- a/tests/InMemoryListenerTest.php
+++ b/tests/InMemoryListenerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once dirname(__FILE__).'/../example/InMemoryListener.php';
+
+class InMemoryListenerTest extends \PHPUnit_Framework_TestCase
+{
+  public function testExampleJson() {
+    $testfile = dirname(__FILE__).'/../example/example.json';
+    $this->assertParsesCorrectly($testfile);
+  }
+
+  public function testGeoJson() {
+    $testfile = dirname(__FILE__).'/../example/geojson/example.geojson';
+    $this->assertParsesCorrectly($testfile);
+  }
+
+  private function assertParsesCorrectly($testfile) {
+    // Parse using an InMemoryListener instance
+    $listener = new InMemoryListener();
+    $stream = fopen($testfile, 'r');
+    try {
+      $parser = new JsonStreamingParser_Parser($stream, $listener);
+      $parser->parse();
+      fclose($stream);
+    } catch (Exception $e) {
+      fclose($stream);
+      throw $e;
+    }
+    $actual = $listener->get_json();
+
+    // Parse using json_decode
+    $expected = json_decode(file_get_contents($testfile), true);
+
+    // Make sure the two produce the same object structure
+    $this->assertSame($expected, $actual);
+  }
+}


### PR DESCRIPTION
@gonzofy I fixed the example in-memory listener a few days after #24 rolled in, then totally forgot I'd done it. Take a look when you have the chance.