### PR TITLE
Small performance additions (may be controversial)

### DIFF
--- a/src/JsonStreamingParser/Listener.php
+++ b/src/JsonStreamingParser/Listener.php
@@ -1,8 +1,6 @@
 <?php
 interface JsonStreamingParser_Listener {
 
-  public function file_position($line, $char);
-
   public function start_document();
   public function end_document();
 

--- a/src/JsonStreamingParser/Listener/IdleListener.php
+++ b/src/JsonStreamingParser/Listener/IdleListener.php
@@ -7,8 +7,6 @@ namespace JsonStreamingParser\Listener;
  */
 class IdleListener implements \JsonStreamingParser_Listener
 {
-  public function file_position($line, $char) {}
-
   public function start_document() {}
 
   public function end_document() {}

--- a/src/JsonStreamingParser/Listener/SubsetConsumer.php
+++ b/src/JsonStreamingParser/Listener/SubsetConsumer.php
@@ -13,10 +13,6 @@ abstract class SubsetConsumer implements \JsonStreamingParser_Listener
    */
   abstract protected function consume($data);
 
-  public function file_position($line, $char) {
-
-  }
-
   public function start_document()
   {
     $this->keyValueStack = array();

--- a/src/JsonStreamingParser/Parser.php
+++ b/src/JsonStreamingParser/Parser.php
@@ -56,6 +56,7 @@ class JsonStreamingParser_Parser {
     $this->_stream = $stream;
     $this->_listener = $listener;
     $this->_emit_whitespace = $emit_whitespace;
+    $this->_emit_file_position = method_exists($listener, 'file_position');
 
     $this->_state = self::STATE_START_DOCUMENT;
     $this->_stack = array();
@@ -83,7 +84,9 @@ class JsonStreamingParser_Parser {
 
       $byteLen = strlen($line);
       for ($i = 0; $i < $byteLen; $i++) {
-        $this->_listener->file_position($this->_line_number, $this->_char_number);
+        if($this->_emit_file_position) {
+          call_user_func([$this->_listener, 'file_position'], $this->_line_number, $this->_char_number);
+        }
         $this->_consume_char($line[$i]);
         $this->_char_number++;
       }

--- a/src/JsonStreamingParser/Parser.php
+++ b/src/JsonStreamingParser/Parser.php
@@ -214,7 +214,7 @@ class JsonStreamingParser_Parser {
         break;
 
       case self::STATE_IN_NUMBER:
-        if (preg_match('/\d/', $c)) {
+        if (ctype_digit($c)) {
           $this->_buffer .= $c;
         } elseif ($c === '.') {
           if (strpos($this->_buffer, '.') !== false) {
@@ -277,7 +277,7 @@ class JsonStreamingParser_Parser {
   }
 
   private function _is_hex_character($c) {
-    return preg_match('/[0-9a-fA-F]/u', $c);
+    return ctype_xdigit($c);
   }
 
   // Thanks: http://stackoverflow.com/questions/1805802/php-convert-unicode-codepoint-to-utf-8
@@ -291,7 +291,7 @@ class JsonStreamingParser_Parser {
 
   private function _is_digit($c) {
     // Only concerned with the first character in a number.
-    return preg_match('/[0-9]|-/u',$c);
+    return ctype_digit($c) || $c === '-';
   }
 
 
@@ -470,7 +470,7 @@ class JsonStreamingParser_Parser {
 
   private function _end_number() {
     $num = $this->_buffer;
-    if (preg_match('/\./', $num)) {
+    if (strpos($num, '.') !== false) {
       $num = (float)($num);
     } else {
       $num = (int)($num);

--- a/src/JsonStreamingParser/Parser.php
+++ b/src/JsonStreamingParser/Parser.php
@@ -33,6 +33,7 @@ class JsonStreamingParser_Parser {
    */
   private $_listener;
   private $_emit_whitespace;
+  private $_emit_file_position;
 
   private $_buffer;
   private $_buffer_size;

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -160,6 +160,15 @@ JSON
     $parser->parse();
   }
 
+  public function testFilePositionIsCalledIfDefined() {
+    $stub = new TestFilePositionListener();
+
+    $parser = new \JsonStreamingParser_Parser(fopen(__DIR__ . '/../example/example.json', 'r'), $stub);
+    $parser->parse();
+
+    $this->assertTrue($stub->called);
+  }
+
   private static function inMemoryStream($content)
   {
     $stream = fopen('php://memory', 'rw');
@@ -236,5 +245,13 @@ class TestListener implements \JsonStreamingParser_Listener
   private static function stringify($value)
   {
     return strlen($value) ? $value : var_export($value, true);
+  }
+}
+
+class TestFilePositionListener extends TestListener {
+  public $called = false;
+
+  public function file_position($line, $char) {
+    $this->called = true;
   }
 }


### PR DESCRIPTION
In this changeset I've done two changes, whereas one may be disputed.
First I've removed all regex functions. This gave a very small improvement, almost negligible, but it's something.

Secondly, I made the file_position method optional on the listener. This is probably a more controversial change, but the performance benefit is 15-20%. If it was removed entirely, the performance benefit would be between 20-25%. Unfortunately, if you actually rely on file_position, this change set has a performance penalty compared to master. For me this is a no-brainer, but assume others will have some opinions.

Put differently: Parsing a 500MB file with ~1.2M entries, I now save 10 minutes.

I did 10 test runs (`for run in {1..10}; do php tests/performance.php; done`) of the perf branch vs master,  here are the results:

| phaza/perf | salsify/master | gain |
|--------------------|----------------|-------|
|9.107668877|10.67672706|14.70%|
|8.819965124|11.25982618|21.67%|
|9.094146967|10.73865008|15.31%|
|8.585276127|10.50739408|18.29%|
|9.22768712|10.99455309|16.07%|
|9.032989979|10.81993604|16.52%|
|8.707053185|10.64168501|18.18%|
|9.159993887|10.44938397|12.34%|
|8.928499937|10.909729|18.16%|
|8.877639771|11.15229297|20.40%|
|-----------------|------------------|----------|
|8.954092097|10.81501775|17.16%|