### PR TITLE
Small improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: php
 php:
-  - "5.3"
-  - "5.4"
-  - "5.5"
-  - "5.6"
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: 7.0
+    - php: hhvm
 
 before_script:
   - composer install --dev

--- a/example/InMemoryListener.php
+++ b/example/InMemoryListener.php
@@ -41,7 +41,7 @@ class InMemoryListener extends JsonStreamingParser\Listener\IdleListener {
   }
 
   public function key($key) {
-    array_push($this->_keys, $key);
+    $this->_keys[] = $key;
   }
 
   public function value($value) {
@@ -52,7 +52,7 @@ class InMemoryListener extends JsonStreamingParser\Listener\IdleListener {
     // We keep a stack of complex values (i.e. arrays and objects) as we build them,
     // tagged with the type that they are so we know how to add new values.
     $current_item = array('type' => $type, 'value' => array());
-    array_push($this->_stack, $current_item);
+    $this->_stack[] = $current_item;
   }
 
   private function _end_complex_value() {
@@ -80,10 +80,10 @@ class InMemoryListener extends JsonStreamingParser\Listener\IdleListener {
     if ($current_item['type'] === 'object') {
       $current_item['value'][array_pop($this->_keys)] = $value;
     } else {
-      array_push($current_item['value'], $value);
+      $current_item['value'][] = $value;
     }
 
     // Replace the current item on the stack.
-    array_push($this->_stack, $current_item);
+    $this->_stack[] = $current_item;
   }
 }

--- a/example/geojson/example.php
+++ b/example/geojson/example.php
@@ -36,7 +36,7 @@ class GeoJsonParser implements JsonStreamingParser_Listener {
 
     public function start_object() {
         $this->_level++;
-        array_push($this->_stack, array());
+        $this->_stack[] = array();
         // Reset the stack when entering the second level
         if($this->_level == 2) {
             $this->_stack = array();
@@ -79,9 +79,9 @@ class GeoJsonParser implements JsonStreamingParser_Listener {
             $obj[$this->_key[$this->_level]] = $value;
             $this->_key[$this->_level] = null;
         } else {
-            array_push($obj, $value);
+            $obj[] = $value;
         }
-        array_push($this->_stack, $obj);
+        $this->_stack[] = $obj;
     }
 
     public function whitespace($whitespace) {

--- a/src/JsonStreamingParser/Listener/SubsetConsumer.php
+++ b/src/JsonStreamingParser/Listener/SubsetConsumer.php
@@ -24,7 +24,7 @@ abstract class SubsetConsumer implements \JsonStreamingParser_Listener
 
   public function start_object()
   {
-    array_push($this->keyValueStack, is_null($this->key) ? array(array()) : array($this->key => array()));
+    $this->keyValueStack[] = is_null($this->key) ? array(array()) : array($this->key => array());
     $this->key = null;
   }
 
@@ -64,9 +64,9 @@ abstract class SubsetConsumer implements \JsonStreamingParser_Listener
     if ($this->key) {
       $keyValue[$objKey][$this->key] = $value;
     } else {
-      array_push($keyValue[$objKey], $value);
+      $keyValue[$objKey][] = $value;
     }
-    array_push($this->keyValueStack, $keyValue);
+    $this->keyValueStack[] = $keyValue;
   }
 
   public function whitespace($whitespace) {

--- a/src/JsonStreamingParser/Parser.php
+++ b/src/JsonStreamingParser/Parser.php
@@ -327,7 +327,7 @@ class JsonStreamingParser_Parser {
   private function _start_array() {
     $this->_listener->start_array();
     $this->_state = self::STATE_IN_ARRAY;
-    array_push($this->_stack, self::STACK_ARRAY);
+    $this->_stack[] = self::STACK_ARRAY;
   }
 
   private function _end_array() {
@@ -348,7 +348,7 @@ class JsonStreamingParser_Parser {
   private function _start_object() {
     $this->_listener->start_object();
     $this->_state = self::STATE_IN_OBJECT;
-    array_push($this->_stack, self::STACK_OBJECT);
+    $this->_stack[] = self::STACK_OBJECT;
   }
 
   private function _end_object() {
@@ -366,12 +366,12 @@ class JsonStreamingParser_Parser {
   }
 
   private function _start_string() {
-    array_push($this->_stack, self::STACK_STRING);
+    $this->_stack[] = self::STACK_STRING;
     $this->_state = self::STATE_IN_STRING;
   }
 
   private function _start_key() {
-    array_push($this->_stack, self::STACK_KEY);
+    $this->_stack[] = self::STACK_KEY;
     $this->_state = self::STATE_IN_STRING;
   }
 
@@ -424,7 +424,7 @@ class JsonStreamingParser_Parser {
       throw new JsonStreamingParser_ParsingError($this->_line_number, $this->_char_number,
         "Expected hex character for escaped Unicode character. Unicode parsed: " . implode($this->_unicode_buffer) . " and got: ".$c);
     }
-    array_push($this->_unicode_buffer, $c);
+    $this->_unicode_buffer[] = $c;
     if (count($this->_unicode_buffer) === 4) {
       $codepoint = hexdec(implode($this->_unicode_buffer));
 

--- a/src/JsonStreamingParser/Parser.php
+++ b/src/JsonStreamingParser/Parser.php
@@ -46,7 +46,7 @@ class JsonStreamingParser_Parser {
   private $_char_number;
 
 
-  public function __construct($stream, $listener, $line_ending = "\n", $emit_whitespace = false) {
+  public function __construct($stream, $listener, $line_ending = "\n", $emit_whitespace = false, $buffer_size = 8192) {
     if (!is_resource($stream) || get_resource_type($stream) != 'stream') {
       throw new InvalidArgumentException("Argument is not a stream");
     }
@@ -63,7 +63,7 @@ class JsonStreamingParser_Parser {
     $this->_stack = array();
 
     $this->_buffer = '';
-    $this->_buffer_size = 8192;
+    $this->_buffer_size = $buffer_size;
     $this->_unicode_buffer = array();
     $this->_unicode_escape_buffer = '';
     $this->_unicode_high_surrogate = -1;


### PR DESCRIPTION
Hi, I have improved the performance a bit. These changes will not break current implementations.
 * I refactored all `array_push($foo, $bar)` to `$foo[] = $bar` because the result of `array_push` was not used.
 * I add a buffer size for the file read operation to read bigger file parts of one line json.
 * I changed the order of the case statements in the switch statement for the parser states. This change will improve the performance about 15%, but it depends on the json (tested with php 5.4 and 5.5).
 * I also add PHP7 and HHVM for test running.
