### PR TITLE
Avoid unnecessary BOM checks

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -187,7 +187,7 @@ class Parser
     private function consumeChar($c)
     {
         // see https://en.wikipedia.org/wiki/Byte_order_mark
-        if ($this->lineNumber == 1 && $this->checkAndSkipUtfBom($c)) {
+        if ($this->charNumber < 5 && $this->lineNumber == 1 && $this->checkAndSkipUtfBom($c)) {
             return;
         }
 


### PR DESCRIPTION
Overhead of method calls can be significant when parsing very large
JSON files. Only checking for the BOM at the first four characters of
a file makes for an easy performance improvement.

The difference in parsing speed is negligible for files like
'tests/ratherBig.json'. When parsing a 50+ megabyte single line of
JSON with lots of string data and using a light-weight listener, this
improvement can cut the parsing time in half.