### PR TITLE
Package cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text          eol=lf
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 
 matrix:
@@ -13,4 +15,4 @@ matrix:
 before_script:
   - composer install --dev
 
-script: ./phpunit
+script: vendor/bin/phpunit

--- a/phpunit
+++ b/phpunit
@@ -1,1 +1,0 @@
-./vendor/bin/phpunit


### PR DESCRIPTION
`./phpunit` as relative symlink breaks host application build using [phar-composer](https://github.com/clue/phar-composer).

The library code is quite compact, but test data is not, `/tests export-ignore` will help to keep composer-distributed package lightweight.

Thanks for handy library!