### PR TITLE
Added a composer install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Installation
 
 To install `JsonStreamingParser` you can either clone this repository or you can use composer
 
-```composer require salsify/json-streaming-parser
+```
+composer require salsify/json-streaming-parser
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ If you've ever used a [SAX parser](http://en.wikipedia.org/wiki/Simple_API_for_X
 This package is compliant with [PSR-4](http://www.php-fig.org/psr/4/), [PSR-1](http://www.php-fig.org/psr/1/), and [PSR-2](http://www.php-fig.org/psr/2/).
 If you notice compliance oversights, please send a patch via pull request.
 
+Installation
+-----
+
+To install `JsonStreamingParser` you can either clone this repository or you can use composer
+
+```composer require salsify/json-streaming-parser
+```
 
 Usage
 -----


### PR DESCRIPTION
Since the composer require command isn't really straight forward due to the added dashes I thought i'd add a pull request adding this feature.

https://github.com/salsify/jsonstreamingparser/issues/55