### PR TITLE
Added stream_set_chunk_size to the underlying stream in the parse()-function

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -146,6 +146,8 @@ class Parser
 
         while (!feof($this->stream) && !$eof) {
             $pos = ftell($this->stream);
+            // set the underlying streams chunk size, so it delivers according to the request from stream_get_line
+            stream_set_chunk_size($this->stream, $this->bufferSize);
             $line = stream_get_line($this->stream, $this->bufferSize, $this->lineEnding);
 
             if (false === $line) {


### PR DESCRIPTION
Because of an observed behaviour in another repo [felixdorn/twitter-stream-api](https://github.com/felixdorn/twitter-stream-api/issues/20). Where no data is being processed, I made an addition to this repository.

Because of the Guzzle response stream not being fed to the `stream_get_line` function, much data had to be received before taking effect. 

This commit adds setting of the chunk size in underlying streams. Tested with guzzle request (stream=true).