### PR TITLE
Removes the void return hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "8.0-dev"
+      "dev-master": "8.3-dev"
     }
   }
 }

--- a/src/Listener/ListenerInterface.php
+++ b/src/Listener/ListenerInterface.php
@@ -6,24 +6,24 @@ namespace JsonStreamingParser\Listener;
 
 interface ListenerInterface
 {
-    public function startDocument(): void;
+    public function startDocument();
 
-    public function endDocument(): void;
+    public function endDocument();
 
-    public function startObject(): void;
+    public function startObject();
 
-    public function endObject(): void;
+    public function endObject();
 
-    public function startArray(): void;
+    public function startArray();
 
-    public function endArray(): void;
+    public function endArray();
 
-    public function key(string $key): void;
+    public function key(string $key);
 
     /**
      * @param mixed $value the value as read from the parser, it may be a string, integer, boolean, etc
      */
     public function value($value);
 
-    public function whitespace(string $whitespace): void;
+    public function whitespace(string $whitespace);
 }


### PR DESCRIPTION
The void return hints didn't provide any value to the interface. If anything, it prevented the streaming solution from being used in a way that aligns best with its implementation: yielding values when you're ready to process them.

The result was that you'd have to compile your entire data set created via the stream, thereby somewhat mitigating its effectiveness.

This PR resolves that, by allowing the yield keyword to be used at any point during the stream's execution.

Solves Issue #99 